### PR TITLE
Implement an optimal pickup spawn mode

### DIFF
--- a/Classes/Menu_TabAMAdmin.uc
+++ b/Classes/Menu_TabAMAdmin.uc
@@ -3,6 +3,7 @@ class Menu_TabAMAdmin extends UT2k3TabPanel;
 var bool bAdmin;
 
 var moComboBox MapList;
+var moComboBox PickupModeList;
 var string MapName;
 var array<string> Maps;
 
@@ -34,7 +35,12 @@ function InitComponent(GUIController MyController, GUIComponent MyOwner)
     moEditBox(Controls[16]).SetText(string(TAM_GRI(PlayerOwner().Level.GRI).CampThreshold));  
 
     moCheckBox(Controls[17]).Checked(TAM_GRI(PlayerOwner().Level.GRI).bForceRUP);    
-    moCheckBox(Controls[18]).Checked(TAM_GRI(PlayerOwner().Level.GRI).bRandomPickups);
+
+    PickupModeList = moComboBox(Controls[18]);
+    PickupModeList.AddItem("Off");
+    PickupModeList.AddItem("Random");
+    PickupModeList.AddItem("Optimal");
+    PickupModeList.SilentSetIndex(TAM_GRI(PlayerOwner().Level.GRI).PickupMode);
 
     MapName = Left(string(PlayerOwner().Level), InStr(string(PlayerOwner().Level), "."));
     
@@ -101,7 +107,7 @@ function bool OnClick(GUIComponent C)
         s = s$"?CampThreshold="$moEditBox(Controls[16]).GetText();
         
         s = s$"?ForceRUP="$moCheckBox(Controls[17]).IsChecked();
-        s = s$"?RandomPickups="$moCheckBox(Controls[18]).IsChecked();
+        s = s$"?PickupMode="$PickupModeList.GetText();
 
         if(Misc_Player(PlayerOwner())  != None)
         {
@@ -345,14 +351,15 @@ defaultproperties
      End Object
      Controls(17)=moCheckBox'3SPNvSoL.Menu_TabAMAdmin.ForceCheck'
 
-     Begin Object Class=moCheckBox Name=PickupCheck
-         Caption="Random Pickups"
-         OnCreateComponent=PickupCheck.InternalOnCreateComponent
+     Begin Object Class=moComboBox Name=PickupModeBox
+         CaptionWidth=0.600000
+         Caption="Pickup Mode:"
+         OnCreateComponent=PickupModeBox.InternalOnCreateComponent
          WinTop=0.700000
          WinLeft=0.550000
          WinWidth=0.400000
-         OnChange=Menu_TabAMAdmin.OnChange
+         WinHeight=0.060000
      End Object
-     Controls(18)=moCheckBox'3SPNvSoL.Menu_TabAMAdmin.PickupCheck'
+     Controls(18)=moComboBox'3SPNvSoL.Menu_TabAMAdmin.PickupModeBox'
 
 }

--- a/Classes/Menu_TabTAMAdmin.uc
+++ b/Classes/Menu_TabTAMAdmin.uc
@@ -3,6 +3,7 @@ class Menu_TabTAMAdmin extends UT2k3TabPanel;
 var bool bAdmin;
 
 var moComboBox MapList;
+var moComboBox PickupModeList;
 var string MapName;
 var array<string> Maps;
 
@@ -36,7 +37,12 @@ function InitComponent(GUIController MyController, GUIComponent MyOwner)
     moEditBox(Controls[17]).SetText(string(TAM_GRI(PlayerOwner().Level.GRI).CampThreshold));  
 
     moCheckBox(Controls[18]).Checked(TAM_GRI(PlayerOwner().Level.GRI).bForceRUP);
-    moCheckBox(Controls[19]).Checked(TAM_GRI(PlayerOwner().Level.GRI).bRandomPickups);
+
+    PickupModeList = moComboBox(Controls[19]);
+    PickupModeList.AddItem("Off");
+    PickupModeList.AddItem("Random");
+    PickupModeList.AddItem("Optimal");
+    PickupModeList.SilentSetIndex(TAM_GRI(PlayerOwner().Level.GRI).PickupMode);
 
     MapName = Left(string(PlayerOwner().Level), InStr(string(PlayerOwner().Level), "."));
 
@@ -105,7 +111,7 @@ function bool OnClick(GUIComponent C)
         s = s$"?CampThreshold="$moEditBox(Controls[17]).GetText();
         
         s = s$"?ForceRUP="$moCheckBox(Controls[18]).IsChecked();
-        s = s$"?RandomPickups="$moCheckBox(Controls[19]).IsChecked();
+        s = s$"?PickupMode="$PickupModeList.GetText();
 
         if(Misc_Player(PlayerOwner())  != None)
         {
@@ -361,15 +367,16 @@ defaultproperties
      End Object
      Controls(18)=moCheckBox'3SPNvSoL.Menu_TabTAMAdmin.ForceCheck'
 
-     Begin Object Class=moCheckBox Name=PickupCheck
-         Caption="Random Pickups"
-         OnCreateComponent=PickupCheck.InternalOnCreateComponent
+     Begin Object Class=moComboBox Name=PickupModeBox
+         CaptionWidth=0.600000
+         Caption="Pickup Mode:"
+         OnCreateComponent=PickupModeBox.InternalOnCreateComponent
          WinTop=0.700000
          WinLeft=0.550000
          WinWidth=0.400000
-         OnChange=Menu_TabTAMAdmin.OnChange
+         WinHeight=0.060000
      End Object
-     Controls(19)=moCheckBox'3SPNvSoL.Menu_TabTAMAdmin.PickupCheck'
+     Controls(19)=moComboBox'3SPNvSoL.Menu_TabTAMAdmin.PickupModeBox'
 
      Begin Object Class=moEditBox Name=TOBox
          CaptionWidth=0.600000

--- a/Classes/Misc_OptimalPickupSpawner.uc
+++ b/Classes/Misc_OptimalPickupSpawner.uc
@@ -1,0 +1,252 @@
+class Misc_OptimalPickupSpawner extends Misc_PickupSpawner
+    notplaceable;
+
+struct Configuration
+{
+    var float Score;
+    var Actor PrimaryActor;
+    var Actor SecondaryActors[2];
+};
+
+var() int MaxCenters;
+var() int MaxConfigurations;
+var() bool bRandomize;
+var array<Configuration> Configurations;
+var array<Misc_PickupBase> Bases;
+
+// SpawnPickups spawns pickups at the best configuration found.
+//
+// If bRandomize is true, then randomly select 1 out of the best.
+function SpawnPickups()
+{
+    local Configuration Best;
+
+    if (Configurations.Length == 0 && MaxConfigurations > 0)
+        FindBestConfigurations();
+
+    if (Configurations.Length == 0)
+        return;
+
+    Best = Configurations[0];
+    if (bRandomize)
+        Best = Configurations[Rand(Configurations.Length)];
+
+    SpawnConfiguration(Best);
+}
+
+// SpawnConfiguration spawns pickups at the given configuration.
+function SpawnConfiguration(Configuration Cfg)
+{
+    local Misc_PickupBase Current;
+    local int i;
+
+    if (Cfg.PrimaryActor != None)
+    {
+        Current = Spawn(class'Misc_PickupBase',,, Cfg.PrimaryActor.Location, Cfg.PrimaryActor.Rotation);
+        Current.MyMarker = InventorySpot(Cfg.PrimaryActor);
+        Bases[Bases.Length] = Current;
+    }
+
+    for (i = 0; i < 2; i++)
+    {
+        if (Cfg.SecondaryActors[i] == None)
+            continue;
+
+        Current = Spawn(class'Misc_PickupBase',,, Cfg.SecondaryActors[i].Location, Cfg.SecondaryActors[i].Rotation);
+        Current.MyMarker = InventorySpot(Cfg.SecondaryActors[i]);
+        Bases[Bases.Length] = Current;
+    }
+}
+
+// FindBestConfigurations searches for the "best" way to position pickups on
+// the map. It follows the following algorithm:
+//
+// * Search for a location closest to the center of the map, determined by
+//   averaging the location of all potentional spawn locations.
+// * Find the remaining spawn locations by maximizing the distance from each
+//   other and from the center point.
+// * Maintain the Configurations list containing the best configurations in
+//   sorted order. The size of this list is govern by MaxConfigurations, though
+//   it is possible it may be less.
+function FindBestConfigurations()
+{
+    local array<Actor> Actors;
+    local array<Actor> CenterMostActors;
+    local NavigationPoint N;
+    local vector CenterPoint;
+    local int i, j, k;
+    local Configuration Cfg;
+
+    // Build a list of potential actors to replace
+    for (N = Level.NavigationPointList; N != None; N = N.NextNavigationPoint)
+    {
+        if (InventorySpot(N) == None || InventorySpot(N).myPickupBase == None)
+            continue;
+
+        Actors[Actors.Length] = N;
+        CenterPoint += N.Location;
+    }
+
+    CenterPoint /= Actors.Length;
+
+    // Find the center most actors
+    CenterMostActors.Length = Max(0, MaxCenters);
+    FindNearestActors(CenterPoint, Actors, CenterMostActors);
+
+    // Remove center most actors from the list of actors
+    RemoveActors(Actors, CenterMostActors);
+
+    // Find the best configurations
+    Configurations.Length = Max(0, MaxConfigurations);
+
+    for (i = 0; i < CenterMostActors.Length; i++)
+    {
+        j = 0;
+        k = 0;
+
+        while (NextCombination(Actors.Length, j, k))
+        {
+            // Maximize the distance between each other and from the
+            // designated center point
+            Cfg.Score = VSize(Actors[j].Location - Actors[k].Location)
+                    * VSize(Actors[j].Location - CenterMostActors[i].Location)
+                    * VSize(Actors[k].Location - CenterMostActors[i].Location);
+
+            Cfg.PrimaryActor = CenterMostActors[i];
+            Cfg.SecondaryActors[0] = Actors[j];
+            Cfg.SecondaryActors[1] = Actors[k];
+
+            InsertConfiguration(Cfg);
+        }
+    }
+
+    TrimConfigurations();
+}
+
+// RemoveActors removes all actors in the Remove array from the From array.
+function RemoveActors(out array<Actor> From, array<Actor> Remove)
+{
+    local bool bRemove;
+    local int i, j;
+
+    for (i = From.Length - 1; i >= 0; i--)
+    {
+        bRemove = false;
+        for (j = 0; j < Remove.Length; j++)
+        {
+            if (From[i] == Remove[j])
+            {
+                bRemove = true;
+                break;
+            }
+        }
+
+        if (bRemove)
+        {
+            From[i] = From[From.Length - 1];
+            From.Length = From.Length - 1;
+        }
+    }
+}
+
+// InsertConfiguration inserts the configuration to the Configurations array in
+// sorted order.
+//
+// Maintains the invariant Configurations.Size <= MaxConfigurations.
+function InsertConfiguration(Configuration Cfg)
+{
+    local int i;
+
+    // Find where to place it in the list of configurations
+    for (i = Configurations.Length - 1; i >= 0 && Cfg.Score > Configurations[i].Score; i--)
+    {
+        if (i + 1 < Configurations.Length)
+            Configurations[i+1] = Configurations[i];
+
+        Configurations[i] = Cfg;
+    }
+}
+
+// TrimConfigurations removes any invalid configurations from the
+// Configurations list. This may happen if we have find less configurations
+// than MaxConfigurations.
+function TrimConfigurations()
+{
+    local int i;
+
+    for (i = 0; i < Configurations.Length; i++)
+    {
+        if (Configurations[i].PrimaryActor == None)
+        {
+            Configurations.Length = i;
+            break;
+        }
+    }
+}
+
+// NextCombination returns the next combination of i and j indexes from an
+// array of size n.
+function bool NextCombination(int n, out int i, out int j)
+{
+    // Initialize the base case
+    if (i == 0 && j == 0)
+    {
+        j = 1;
+        return true;
+    }
+
+    // Find the next combination
+    j += 1;
+    if (j >= n)
+    {
+        i += 1;
+        if (i >= n - 1)
+            return false;
+        j = i + 1;
+    }
+
+    return true;
+}
+
+// FindNearestActors populates Nearest with the actors closest to References.
+// The number of actors inserted is determined by the length of the Nearest
+// array.
+function FindNearestActors(vector Reference, array<Actor> Actors, out array<Actor> Nearest)
+{
+    local array<float> NearestScores;
+    local float Score;
+    local int i, j;
+
+    if (Actors.Length == 0 || Nearest.Length == 0)
+        return;
+
+    // Initialize scores
+    for (i = 0; i < Nearest.Length; i++)
+    {
+        NearestScores[NearestScores.Length] = 1000000;
+    }
+
+    for (i = 0; i < Actors.Length; i++)
+    {
+        Score = VSize(Actors[i].Location - Reference);
+
+        // Find where to place actor in the list
+        for (j = Nearest.Length - 1; j >= 0 && Score < NearestScores[j]; j--)
+        {
+            if (j + 1 < Nearest.Length)
+            {
+                Nearest[j+1] = Nearest[j];
+                NearestScores[j+1] = NearestScores[j];
+            }
+
+            NearestScores[j] = Score;
+            Nearest[j] = Actors[i];
+        }
+    }
+}
+
+defaultproperties {
+    MaxCenters=1
+    MaxConfigurations=3
+    bRandomize=true
+}

--- a/Classes/Misc_PickupSpawner.uc
+++ b/Classes/Misc_PickupSpawner.uc
@@ -1,0 +1,14 @@
+class Misc_PickupSpawner extends Actor
+    abstract
+    notplaceable;
+
+function BeginPlay()
+{
+    Disable('Tick');
+}
+
+function SpawnPickups();
+
+defaultproperties{
+    bHidden=true
+}

--- a/Classes/Misc_RandomPickupSpawner.uc
+++ b/Classes/Misc_RandomPickupSpawner.uc
@@ -1,0 +1,67 @@
+class Misc_RandomPickupSpawner extends Misc_PickupSpawner
+    notplaceable;
+
+var Misc_PickupBase Bases[3];
+
+function SpawnPickups()
+{
+    local int i;
+    local float Score[3];
+    local float eval;
+    local NavigationPoint Best[3];
+    local NavigationPoint N;
+
+    for(i = 0; i < 100; i++)
+        FRand();
+
+    for(i = 0; i < 3; i++)
+    {
+        for(N = Level.NavigationPointList; N != None; N = N.NextNavigationPoint)
+        {
+            if(InventorySpot(N) == None || InventorySpot(N).myPickupBase == None)
+                continue;
+
+            eval = 0;
+
+            if(i == 0)
+                eval = FRand() * 5000.0;
+            else
+            {
+                if(Best[0] != None)
+                    eval = VSize(Best[0].Location - N.Location) * (0.8 + FRand() * 1.2);
+
+                if(i > 1 && Best[1] != None)
+                    eval += VSize(Best[1].Location - N.Location) * (1.5 + FRand() * 0.5);
+            }
+
+            if(Best[0] == N)
+                eval = 0;
+            if(Best[1] == N)
+                eval = 0;
+            if(Best[2] == N)
+                eval = 0;
+
+            if(Score[i] < eval)
+            {
+                Score[i] = eval;
+                Best[i] = N;
+            }
+        }
+    }
+
+    if(Best[0] != None)
+    {
+        Bases[0] = Spawn(class'Misc_PickupBase',,, Best[0].Location, Best[0].Rotation);
+        Bases[0].MyMarker = InventorySpot(Best[0]);
+    }
+    if(Best[1] != None)
+    {
+        Bases[1] = Spawn(class'Misc_PickupBase',,, Best[1].Location, Best[1].Rotation);
+        Bases[1].MyMarker = InventorySpot(Best[1]);
+    }
+    if(Best[2] != None)
+    {
+        Bases[2] = Spawn(class'Misc_PickupBase',,, Best[2].Location, Best[2].Rotation);
+        Bases[2].MyMarker = InventorySpot(Best[2]);
+    }
+}

--- a/Classes/TAM_GRI.uc
+++ b/Classes/TAM_GRI.uc
@@ -2,12 +2,12 @@ class TAM_GRI extends Misc_BaseGRI;
 
 var bool bChallengeMode;
 var bool bDisableTeamCombos;
-var bool bRandomPickups;
+var int  PickupMode;
 
 replication
 {
     reliable if(bNetInitial && Role == ROLE_Authority)
-        bDisableTeamCombos, bChallengeMode, bRandomPickups;
+        bDisableTeamCombos, bChallengeMode, PickupMode;
 }
 
 defaultproperties

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # 3SPNvSoL
 3SPN/TAM mutator customized for SoL, originally based on 3SPNv42102
 
+v3.1
+- Implement an optimal pickup spawn strategy. Pickup spawns are now govern by the `PickupMode` configuration option.
+  - `Off (0)` - No pickups will spawn, same as setting `bRandomPickups` to `false`.
+  - `Random (1)` - Original pickup spawn strategy, same as setting `bRandomPickups` to `true`.
+  - `Optimal (2)` - New pickup spawn strategy.
+
 v3.0
 - fix necro message bug for TAM
 


### PR DESCRIPTION
The existing algorithm sometimes yields pickup bases really close to each other, giving one team an unfair advantage. This implements an "Optimal" placement strategy by performing the following:

* Find a location close to the center of the map to place a static pickup. In most cases, this yields a competitive location for both teams.

* Find two secondary locations by maximizing distance between each other and from the center spawn. This yields a single pickup for each team.

* Randomly select spawn locations from a list of best configurations.

The existing algorithm is retained, however the configuration option is changed from `bRandomPickups` to `PickupMode`. Backwards compatibility is retained by migrating configurations using `bRandomPickups` to `PickupMode`. `bRandomPickups` may be removed at a later release after servers are migrated.