### PR TITLE
Preserve footstep sounds

### DIFF
--- a/Classes/Misc_Pawn.uc
+++ b/Classes/Misc_Pawn.uc
@@ -646,6 +646,11 @@ simulated function Tick(float DeltaTime)
     if(Level.NetMode == NM_DedicatedServer)
         return;
 
+    // Trick the client the pawn is still on screen so it continues to update
+    // movement animations and preserve footsteps sounds.
+    if(PlayerController(Controller) == None)
+        LastRenderTime = Level.TimeSeconds;
+
     if(MyOwner == None)
         MyOwner = Misc_Player(Level.GetLocalPlayerController());
 	if ( Level.NetMode == 1 )


### PR DESCRIPTION
Animations for pawns stop updating 1s after leaving the player's screen. Since foosteps are played with the animations, this results in losing footstep sounds for pawns out of view. This fixes that by tricking the engine into thinking the pawn is still in view.